### PR TITLE
ManaCost:no cost for lands

### DIFF
--- a/forgeLoad.js
+++ b/forgeLoad.js
@@ -125,7 +125,7 @@ function forgeSkeletonWriter(card) {
 	let finished = false;
 	let skele = "";
 	skele += "Name:" + card.cardName;
-	skele += "\nManaCost:"+forgeMana(card.manaCost);
+	skele += "\nManaCost:"+forgeMana(card.manaCost ? card.manaCost : "no cost");
 	skele += "\nTypes:"+card.typeLine.replace(/ —/g, "");
 	if(card.power != "") {
 		skele += "\nPT:" + card.power + "/" + card.toughness;


### PR DESCRIPTION
Forge uses `ManaCost:no cost` when a card has no mana cost.